### PR TITLE
Add option to drop negative signal regions

### DIFF
--- a/R/ECLIPSE_ROSE.R
+++ b/R/ECLIPSE_ROSE.R
@@ -331,6 +331,8 @@ add_region_signal <- function(treatment,
 #' @param regions A `GRanges` object containing the `sample_signal` and optionally `control_signal` in metadata columns.
 #' @param negative.to.zero Logical indicating whether to set negative values in the ranking signal to zero.
 #'   Default is `TRUE`, as that is what ROSE does.
+#' @param drop.negative Logical indicating whether to remove regions with negative values in the ranking signal.
+#'   Default is `FALSE`.
 #'
 #' @return A `GRanges` object with an added `rank_signal` column containing the
 #'   computed `rank_signal` column in its metadata columns, sorted by said column.
@@ -352,7 +354,7 @@ add_region_signal <- function(treatment,
 #' regions$sample_signal <- rnorm(length(regions))
 #' regions$control_signal <- rnorm(length(regions))
 #' ranked_regions <- add_signal_rank(regions)
-add_signal_rank <- function(regions, negative.to.zero = TRUE) {
+add_signal_rank <- function(regions, negative.to.zero = TRUE, drop.negative = FALSE) {
     if (is.null(regions$sample_signal)) {
         stop("regions must contain signal, run 'get_region_signal'")
     }
@@ -367,6 +369,13 @@ add_signal_rank <- function(regions, negative.to.zero = TRUE) {
 
     if (negative.to.zero) {
         rank_sig[rank_sig < 0] <- 0
+    }
+
+    if (drop.negative) {
+        num_dropped_regions <- sum(rank_sig < 0)
+        message(paste("Dropped", num_dropped_regions, "regions due to negative signal"))
+        regions <- regions[rank_sig >= 0]
+        rank_sig <- rank_sig[rank_sig >= 0]
     }
 
     regions$rank_signal <- rank_sig
@@ -536,6 +545,8 @@ classify_enhancers <- function(regions,
 #'   Default is 50. Ignored if `txdb` is `NULL`.
 #' @param negative.to.zero Logical indicating whether to set negative ranking signals to zero.
 #'   Default is `TRUE`.
+#' @param drop.negative Logical indicating whether to remove regions with negative values in the ranking signal.
+#'   Default is `FALSE`.
 #' @param thresh.method Character string specifying the method to determine the signal threshold.
 #'   Must be one of "ROSE", "first", "curvature", or "arbitrary".
 #'   Default is "ROSE".
@@ -600,6 +611,7 @@ run_rose <- function(
     max.unique.gene.tss.overlap = NULL,
     tss.overlap.distance = 50,
     negative.to.zero = TRUE,
+    drop.negative = FALSE,
     thresh.method = "ROSE",
     transformation = NULL,
     floor = 1,
@@ -692,7 +704,7 @@ run_rose <- function(
     regions <- add_region_signal(treatment, peaks_stitched, control = control, floor = floor, read.ext = read.ext, normalize.by.width = normalize.by.width)
 
     message("Ranking regions")
-    regions <- add_signal_rank(regions, negative.to.zero = negative.to.zero)
+    regions <- add_signal_rank(regions, negative.to.zero = negative.to.zero, drop.negative = drop.negative)
 
     message("Classifying enhancers")
     regions <- classify_enhancers(regions,

--- a/man/add_signal_rank.Rd
+++ b/man/add_signal_rank.Rd
@@ -4,13 +4,16 @@
 \alias{add_signal_rank}
 \title{Get ranking signal for regions and add to GRanges object}
 \usage{
-add_signal_rank(regions, negative.to.zero = TRUE)
+add_signal_rank(regions, negative.to.zero = TRUE, drop.no.signal = FALSE)
 }
 \arguments{
 \item{regions}{A \code{GRanges} object containing the \code{sample_signal} and optionally \code{control_signal} in metadata columns.}
 
 \item{negative.to.zero}{Logical indicating whether to set negative values in the ranking signal to zero.
 Default is \code{TRUE}, as that is what ROSE does.}
+
+\item{drop.no.signal}{Logical indicating whether to remove regions with negative or zero values in the ranking signal.
+Default is \code{FALSE}.}
 }
 \value{
 A \code{GRanges} object with an added \code{rank_signal} column containing the

--- a/man/run_rose.Rd
+++ b/man/run_rose.Rd
@@ -16,6 +16,7 @@ run_rose(
   max.unique.gene.tss.overlap = NULL,
   tss.overlap.distance = 50,
   negative.to.zero = TRUE,
+  drop.no.signal = FALSE,
   thresh.method = "ROSE",
   transformation = NULL,
   floor = 1,
@@ -65,6 +66,9 @@ Default is 50. Ignored if \code{txdb} is \code{NULL}.}
 
 \item{negative.to.zero}{Logical indicating whether to set negative ranking signals to zero.
 Default is \code{TRUE}.}
+
+\item{drop.no.signal}{Logical indicating whether to remove regions with negative or zero values in the ranking signal.
+Default is \code{FALSE}.}
 
 \item{thresh.method}{Character string specifying the method to determine the signal threshold.
 Must be one of "ROSE", "first", "curvature", or "arbitrary".


### PR DESCRIPTION
Add an option to drop negative signal regions in `add_signal_rank` function.

* **New Parameter**: Add `drop.no.signal` parameter to `add_signal_rank` and `run_rose` functions with a default value of `FALSE`.
* **Functionality**: Modify `add_signal_rank` function to remove negative or zero signal regions when `drop.no.signal` is `TRUE`. Add a message with a count of the regions being dropped.
* **Documentation**: Update documentation in `R/ECLIPSE_ROSE.R`, `man/add_signal_rank.Rd`, and `man/run_rose.Rd` to include the new `drop.no.signal` parameter.