### PR TITLE
Add force parameter to run_rose function

### DIFF
--- a/R/ECLIPSE_ROSE.R
+++ b/R/ECLIPSE_ROSE.R
@@ -636,6 +636,8 @@ classify_enhancers <- function(regions,
 #' @param omit.unknown Logical indicating whether uncharacterized genes (i.e., gene symbols starting with *LOC*)
 #'   should be excluded from annotations.
 #'   Default is `TRUE`.
+#' @param force Logical indicating whether to force recalculation of coverage and stitching even if `sample_signal` is found.
+#'   Default is `FALSE`.
 #'
 #' @return A `GRanges` object containing the classified regions and associated metadata of each,
 #'   including super enhancer status.
@@ -654,7 +656,7 @@ classify_enhancers <- function(regions,
 #' \dontrun{
 #' sample.bam <- "path/to/sample.bam"
 #' peaks <- "path/to/peaks.bed"
-#' result <- run_rose(sample.bam, peaks)
+#' result <- run_rose(sample.bam, peaks, force = TRUE)
 #' }
 run_rose <- function(
     treatment,
@@ -686,7 +688,8 @@ run_rose <- function(
     promoter.dist = c(2000, 200),
     active.genes = NULL,
     identify.active.genes = FALSE,
-    omit.unknown = TRUE) {
+    omit.unknown = TRUE,
+    force = FALSE) {
     # Check that treatment is a BamFile or GRanges object
     if (!is(treatment, "BamFile") && !is(treatment, "GRanges")) {
         stop("treatment must be a BamFile or GRanges object")
@@ -725,60 +728,65 @@ run_rose <- function(
 
     message(length(peaks), " peaks provided")
 
-    if (tss.exclusion.distance > 0) {
-        if (is.null(txdb)) {
-            stop("txdb must be provided if tss.exclusion.distance is greater than 0")
+    if (!force && !is.null(peaks$sample_signal)) {
+        message("sample_signal found in peaks and force is FALSE, skipping recalculating coverage and stitching")
+        regions <- peaks
+    } else {
+        if (tss.exclusion.distance > 0) {
+            if (is.null(txdb)) {
+                stop("txdb must be provided if tss.exclusion.distance is greater than 0")
+            }
+
+            message("Excluding peaks within TSS exclusion distance of ", tss.exclusion.distance)
+            tss <- promoters(txdb, upstream = tss.exclusion.distance, downstream = tss.exclusion.distance, columns = "GENEID")
+
+            # Create susbset of stitched peaks that do not overlap TSS and remove
+            overlaps <- findOverlaps(peaks, tss, type = "within")
+
+            contained_indices <- queryHits(overlaps)
+
+            message(length(unique(contained_indices)), " peaks fully contained within TSS exclusion window and will be excluded from stitching")
+            peaks <- peaks[-unique(contained_indices)]
         }
 
-        message("Excluding peaks within TSS exclusion distance of ", tss.exclusion.distance)
-        tss <- promoters(txdb, upstream = tss.exclusion.distance, downstream = tss.exclusion.distance, columns = "GENEID")
+        message("Stitching peaks with stitch distance of ", stitch.distance)
+        peaks_stitched <- reduce(peaks, min.gapwidth = stitch.distance)
 
-        # Create susbset of stitched peaks that do not overlap TSS and remove
-        overlaps <- findOverlaps(peaks, tss, type = "within")
-
-        contained_indices <- queryHits(overlaps)
-
-        message(length(unique(contained_indices)), " peaks fully contained within TSS exclusion window and will be excluded from stitching")
-        peaks <- peaks[-unique(contained_indices)]
-    }
-
-    message("Stitching peaks with stitch distance of ", stitch.distance)
-    peaks_stitched <- reduce(peaks, min.gapwidth = stitch.distance)
-
-    # Drop chrY as ROSE does
-    if (drop.y) {
-        peaks.chr <- as.vector(seqnames(peaks_stitched))
-        message("Dropped ", length(which(peaks.chr == "chrY")), " peaks on chrY")
-        peaks_stitched <- peaks_stitched[peaks.chr != "chrY"]
-    }
-
-    if (!is.null(max.unique.gene.tss.overlap)) {
-        if (is.null(txdb)) {
-            stop("txdb must be provided if max.unique.gene.tss.overlap is not NULL")
+        # Drop chrY as ROSE does
+        if (drop.y) {
+            peaks.chr <- as.vector(seqnames(peaks_stitched))
+            message("Dropped ", length(which(peaks.chr == "chrY")), " peaks on chrY")
+            peaks_stitched <- peaks_stitched[peaks.chr != "chrY"]
         }
 
-        tss <- promoters(txdb, upstream = tss.overlap.distance, downstream = tss.overlap.distance, columns = "GENEID")
-        message("Unstitching regions overlapping TSS from more than ", max.unique.gene.tss.overlap, " unique genes")
-        unstitched <- unstitch_regions(peaks_stitched, peaks, tss, threshold = max.unique.gene.tss.overlap)
-        peaks_stitched <- unstitched$regions
-        hits <- unstitched$hits
-        message("Unstitched ", sum(hits$unstitch), " regions")
+        if (!is.null(max.unique.gene.tss.overlap)) {
+            if (is.null(txdb)) {
+                stop("txdb must be provided if max.unique.gene.tss.overlap is not NULL")
+            }
+
+            tss <- promoters(txdb, upstream = tss.overlap.distance, downstream = tss.overlap.distance, columns = "GENEID")
+            message("Unstitching regions overlapping TSS from more than ", max.unique.gene.tss.overlap, " unique genes")
+            unstitched <- unstitch_regions(peaks_stitched, peaks, tss, threshold = max.unique.gene.tss.overlap)
+            peaks_stitched <- unstitched$regions
+            hits <- unstitched$hits
+            message("Unstitched ", sum(hits$unstitch), " regions")
+        }
+
+        # Drop all mcols to clean up output and avoid carrying along anything from the original peaks.
+        mcols(peaks_stitched) <- NULL
+
+        # Technically this will be inaccurate, as peaks fully overlapping promoters will be ignored but their signal still utilized.
+        # For each stitched region, we will sum the width of the constituent peaks that overlap it.
+        message("Calculating total constituent peak width for each stitched region")
+        hits <- findOverlaps(peaks_stitched, peaks)
+        peaks_stitched.over <- pintersect(peaks_stitched[queryHits(hits)], peaks[subjectHits(hits)])
+        peaks_stitched.counts <- tapply(peaks_stitched.over, queryHits(hits), FUN=function(x) sum(width(x)))
+        peaks_stitched$total_constituent_width <- 0
+        peaks_stitched$total_constituent_width[as.numeric(names(peaks_stitched.counts))] <- unname(peaks_stitched.counts)
+
+        message("Calculating normalized signal for ", length(peaks_stitched), " stitched regions")
+        regions <- add_region_signal(treatment, peaks_stitched, control = control, floor = floor, read.ext = read.ext, normalize.by.width = normalize.by.width)
     }
-
-    # Drop all mcols to clean up output and avoid carrying along anything from the original peaks.
-    mcols(peaks_stitched) <- NULL
-
-    # Technically this will be inaccurate, as peaks fully overlapping promoters will be ignored but their signal still utilized.
-    # For each stitched region, we will sum the width of the constituent peaks that overlap it.
-    message("Calculating total constituent peak width for each stitched region")
-    hits <- findOverlaps(peaks_stitched, peaks)
-    peaks_stitched.over <- pintersect(peaks_stitched[queryHits(hits)], peaks[subjectHits(hits)])
-    peaks_stitched.counts <- tapply(peaks_stitched.over, queryHits(hits), FUN=function(x) sum(width(x)))
-    peaks_stitched$total_constituent_width <- 0
-    peaks_stitched$total_constituent_width[as.numeric(names(peaks_stitched.counts))] <- unname(peaks_stitched.counts)
-
-    message("Calculating normalized signal for ", length(peaks_stitched), " stitched regions")
-    regions <- add_region_signal(treatment, peaks_stitched, control = control, floor = floor, read.ext = read.ext, normalize.by.width = normalize.by.width)
 
     message("Ranking regions")
     regions <- add_signal_rank(regions, negative.to.zero = negative.to.zero, drop.no.signal = drop.no.signal)

--- a/man/run_rose.Rd
+++ b/man/run_rose.Rd
@@ -34,7 +34,8 @@ run_rose(
   promoter.dist = c(2000, 200),
   active.genes = NULL,
   identify.active.genes = FALSE,
-  omit.unknown = TRUE
+  omit.unknown = TRUE,
+  force = FALSE
 )
 }
 \arguments{
@@ -144,6 +145,9 @@ Default is \code{FALSE}.}
 \item{omit.unknown}{Logical indicating whether uncharacterized genes (i.e., gene symbols starting with \emph{LOC})
 should be excluded from annotations.
 Default is \code{TRUE}.}
+
+\item{force}{Logical indicating whether to force recalculation of coverage and stitching even if \code{sample_signal} is found.
+Default is \code{FALSE}.}
 }
 \value{
 A \code{GRanges} object containing the classified regions and associated metadata of each,
@@ -176,7 +180,7 @@ that result in a consistent curve shape with a known maximum, like cumulative pr
 \dontrun{
 sample.bam <- "path/to/sample.bam"
 peaks <- "path/to/peaks.bed"
-result <- run_rose(sample.bam, peaks)
+result <- run_rose(sample.bam, peaks, force = TRUE)
 }
 }
 \author{

--- a/man/run_rose.Rd
+++ b/man/run_rose.Rd
@@ -5,8 +5,8 @@
 \title{Run ROSE (Rank Ordering of Super-Enhancers)}
 \usage{
 run_rose(
-  treatment,
   peaks,
+  treatment = NULL,
   control = NULL,
   stitch.distance = 12500,
   tss.exclusion.distance = 0,
@@ -39,9 +39,9 @@ run_rose(
 )
 }
 \arguments{
-\item{treatment}{A \code{BamFile} or \code{GRanges} object representing the sample signal.}
-
 \item{peaks}{A  \code{GRanges} object representing the peaks.}
+
+\item{treatment}{A \code{BamFile} or \code{GRanges} object representing the sample signal.}
 
 \item{control}{A \code{BamFile} or \code{GRanges} object representing the control (usually input or IgG) signal.
 Default is \code{NULL}.}
@@ -147,7 +147,7 @@ should be excluded from annotations.
 Default is \code{TRUE}.}
 
 \item{force}{Logical indicating whether to force recalculation of coverage and stitching even if \code{sample_signal} is found.
-Default is \code{FALSE}.}
+Default is \code{TRUE}.}
 }
 \value{
 A \code{GRanges} object containing the classified regions and associated metadata of each,
@@ -180,7 +180,7 @@ that result in a consistent curve shape with a known maximum, like cumulative pr
 \dontrun{
 sample.bam <- "path/to/sample.bam"
 peaks <- "path/to/peaks.bed"
-result <- run_rose(sample.bam, peaks, force = TRUE)
+result <- run_rose(peaks, sample.bam, force = TRUE)
 }
 }
 \author{

--- a/vignettes/ECLIPSE.Rmd
+++ b/vignettes/ECLIPSE.Rmd
@@ -679,6 +679,23 @@ for (i in seq_along(transformed_SEs_width_norm)) {
 dev.off()
 ```
 
+## Re-running with Different Parameters
+
+If already run, one can re-run `run_rose` without performing stitching, re-calculating coverage, and annotating, which is much faster.
+Simply set `force = FALSE` in the `run_rose` call and regigon stitching, coverage calculation, and annotation will be skipped.
+This allows one to test different transformations or thresholding methods very quickly.
+
+```{r}
+# Let's try log2(x + 1) as a transformation.
+naiveB1_enhancers_from_existing <- run_rose(peaks = naiveB1_enhancers,
+                                            transformation = function(x) log2(x + 1), 
+                                            force = FALSE)
+
+plot_enhancer_curve(naiveB1_enhancers_from_existing, factor.label = "H3K27ac", show.legend = FALSE)
+```
+
+Runs almost instantly, huzzah.
+
 ## Differential Sub-Structural Analysis
 
 ECLIPSE also provides functionality to identify sub-structural changes within super enhancer regions between groups via differential analysis of small bins.


### PR DESCRIPTION
Closes #23.

Add `force` parameter to `run_rose()` to allow skipping recalculating coverage and stitching if `sample_signal` is found.

* Add `force` parameter to `run_rose()` function in `R/ECLIPSE_ROSE.R` with default value `FALSE`.
* Add conditional check for `sample_signal` in `regions` object.
* Skip recalculating coverage and stitching if `sample_signal` is found and `force` is `FALSE`.
* Add documentation for `force` parameter in `man/run_rose.Rd`.
* Update usage section and examples in `man/run_rose.Rd` to include `force` parameter.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/j-andrews7/ECLIPSE/pull/25?shareId=4d6135c6-c65e-46db-92a4-bbb6e9a9096b).